### PR TITLE
Allow multi-language code samples

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,12 +8,11 @@ plugins {
 }
 
 apply from: "$rootDir/gradle/functional-test.gradle"
-apply from: "$rootDir/gradle/local-publish.gradle"
 
 buildScan {
     licenseAgreementUrl = 'https://gradle.com/terms-of-service'
     licenseAgree = 'yes'
-    if (!System.getenv("CI")) {
+    if (System.getenv("CI")) {
         publishAlways()
         tag("CI")
     }

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,10 @@ apply from: "$rootDir/gradle/local-publish.gradle"
 buildScan {
     licenseAgreementUrl = 'https://gradle.com/terms-of-service'
     licenseAgree = 'yes'
+    if (!System.getenv("CI")) {
+        publishAlways()
+        tag("CI")
+    }
 }
 
 group = 'org.gradle.guides'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.gradle.build-scan' version '1.12.1'
+    id 'com.gradle.build-scan' version '1.13.1'
     id 'groovy'
     id 'java-gradle-plugin'
     id 'com.gradle.plugin-publish' version '0.9.10'
@@ -8,6 +8,7 @@ plugins {
 }
 
 apply from: "$rootDir/gradle/functional-test.gradle"
+apply from: "$rootDir/gradle/local-publish.gradle"
 
 buildScan {
     licenseAgreementUrl = 'https://gradle.com/terms-of-service'
@@ -15,7 +16,7 @@ buildScan {
 }
 
 group = 'org.gradle.guides'
-version = '0.11.5'
+version = '0.12.0'
 
 repositories {
     jcenter()

--- a/gradle/local-publish.gradle
+++ b/gradle/local-publish.gradle
@@ -1,0 +1,9 @@
+apply plugin: 'maven-publish'
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+        }
+    }
+}

--- a/gradle/local-publish.gradle
+++ b/gradle/local-publish.gradle
@@ -1,9 +1,0 @@
-apply plugin: 'maven-publish'
-
-publishing {
-    publications {
-        maven(MavenPublication) {
-            from components.java
-        }
-    }
-}

--- a/src/functTest/groovy/org/gradle/guides/BasePluginFunctionalTest.groovy
+++ b/src/functTest/groovy/org/gradle/guides/BasePluginFunctionalTest.groovy
@@ -137,7 +137,7 @@ include::{samplesoutputdir}/helloWorld/build.out[]
 
         then:
         def htmlFile = new File(temporaryFolder.root, 'build/html5/index.html').text
-        htmlFile.contains('<script defer src="https://guides.gradle.org/js/guides.js"></script>')
+        htmlFile.contains('<script defer src="https://guides.gradle.org/js/guides')
         htmlFile.contains('<header class="site-layout__header site-header" itemscope="itemscope" itemtype="https://schema.org/WPHeader">')
         htmlFile.contains('<footer class="site-layout__footer site-footer" itemscope="itemscope" itemtype="https://schema.org/WPFooter">')
     }

--- a/src/main/groovy/org/gradle/guides/BasePlugin.groovy
+++ b/src/main/groovy/org/gradle/guides/BasePlugin.groovy
@@ -103,8 +103,7 @@ class BasePlugin implements Plugin<Project> {
             backends 'html5'
             inputs.dir('samples').withPropertyName('samplesDir').withPathSensitivity(PathSensitivity.RELATIVE)
 
-            attributes "source-highlighter": "coderay",
-                    "coderay-linenums-mode": "table",
+            attributes 'source-highlighter': 'prettify',
                     imagesdir            : 'images',
                     stylesheet           : null,
                     linkcss              : true,

--- a/src/main/resources/head-meta.html
+++ b/src/main/resources/head-meta.html
@@ -1,13 +1,13 @@
 <link crossorigin href="//assets.gradle.com" rel="preconnect">
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,400i">
 <link rel="stylesheet" href="https://guides.gradle.org/css/asciidoctor.css">
-<link rel="stylesheet" href="https://guides.gradle.org/css/docs-blue-theme-4.5.2.css">
+<link rel="stylesheet" href="https://guides.gradle.org/css/docs-blue-theme-4.7.css">
 <link rel="apple-touch-icon" sizes="180x180" href="https://guides.gradle.org/icon/apple-touch-icon.png">
 <link rel="icon" type="image/png" href="https://guides.gradle.org/icon/favicon-32x32.png" sizes="32x32">
 <link rel="icon" type="image/png" href="https://guides.gradle.org/icon/favicon-16x16.png" sizes="16x16">
 <link rel="manifest" href="https://guides.gradle.org/icon/manifest.json">
 <link rel="mask-icon" href="https://guides.gradle.org/icon/safari-pinned-tab.svg" color="#5bbad5">
 <link rel="shortcut icon" href="https://guides.gradle.org/icon/favicon.ico">
-<script defer src="https://guides.gradle.org/js/guides.js"></script>
+<script defer src="https://guides.gradle.org/js/guides-4.7.js"></script>
 <script defer src="https://guides.gradle.org/js/set-time-to-complete-text.js"></script>
 <script async src="https://guides.gradle.org/js/autotrack.js"></script>


### PR DESCRIPTION
Functionality:
![multi-lang-sample](https://user-images.githubusercontent.com/51534/38645011-7e696d6e-3d97-11e8-98ce-80c7112f2ddf.gif)

- User selection is remembered in `window.localStorage` by language
- Does nothing if only one language sample provided
- Works in IE9+
- Default title is language if not provided

How to use:

- Samples in multiple language must be right next to each other
- Must provide a language or sample title
- Only 1 set of languages is supported

```
[source.multi-language-sample,groovy]
.build.gradle
----
include::{samplescodedir}/copy.gradle[]
----

[source.multi-language-sample,kotlin]
.build.gradle.kts
----
include::{samplescodedir}/copy.gradle.kts[]
----
```