### PR TITLE
Fix typo in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,7 +15,7 @@ This is a collection of very opinionated plugins that support the authoring of g
 * Adds `asciidoctorAttributes` task.
 * Adds `publishGhPages` task for publishing guide to `gh-pages`. (Used on Travis).
 * Adds special Travis CI support via the `travisci` block.
-* Adds `checkLinks` task to check hyperlinks in generated pages. (In this current release on absolute URLs are supported).
+* Adds `checkLinks` task to check hyperlinks in generated pages. (In the current release only absolute URLs are supported).
 * Adds `gradleRunner` task to allow automating one set of steps described in a guide.
 * Adds docs-asciidoctor-extensions library responsible for injecting navigation and CSS/JS
 


### PR DESCRIPTION
Change from `on` to `only`, also, tweak the reference to the current
release (`the` instead of `this`).