### PR TITLE
Bumped version to 0.15.5. Updated build scan plugin to 2.0.2 to remove build warning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.gradle.build-scan' version '2.0.1'
+    id 'com.gradle.build-scan' version '2.0.2'
     id 'groovy'
     id 'java-gradle-plugin'
     id 'com.gradle.plugin-publish' version '0.10.0'
@@ -19,7 +19,7 @@ buildScan {
 }
 
 group = 'org.gradle.guides'
-version = '0.15.4'
+version = '0.15.5'
 
 repositories {
     jcenter()


### PR DESCRIPTION
Blocking https://github.com/gradle-guides/using-build-cache/pull/41