### PR TITLE
Some improvements to the guide plugins user interface

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -8,6 +8,14 @@ This is a collection of very opinionated plugins that support the authoring of g
 * `org.gradle.guides.tutorial`: Used by all new Tutorials.
 * `org.gradle.guides.test-jvm-code`: Used to test JVM-based code snippets.
 
+== How do I use the plugins?
+
+Each of the plugins generates a guide from Asciidoc source. They all share the same conventions:
+
+- The source for the guide is located in `content/index.adoc`
+- Run `./gradlew asciidoctor` to generate the guide into `build/html5/index.html`.
+- run `./gradlew viewGuide` to generate the guide and open it in the browser.
+
 == Base plugin
 
 * Adds `guide` extension.

--- a/README.adoc
+++ b/README.adoc
@@ -14,7 +14,7 @@ Each of the plugins generates a guide from Asciidoc source. They all share the s
 
 - The source for the guide is located in `content/index.adoc`
 - Run `./gradlew asciidoctor` to generate the guide into `build/html5/index.html`.
-- run `./gradlew viewGuide` to generate the guide and open it in the browser.
+- Run `./gradlew viewGuide` to generate the guide and open it in the browser.
 
 == Base plugin
 

--- a/gradle/functional-test.gradle
+++ b/gradle/functional-test.gradle
@@ -13,7 +13,7 @@ task functionalTest(type: Test) {
     testClassesDirs = sourceSets.functionalTest.output.classesDirs
     classpath = sourceSets.functionalTest.runtimeClasspath
     shouldRunAfter test
-    maxParallelForks = 4
+    maxParallelForks = 2
 
     reports {
         html.destination = project.file("$html.destination/functional")

--- a/gradle/functional-test.gradle
+++ b/gradle/functional-test.gradle
@@ -12,7 +12,8 @@ task functionalTest(type: Test) {
     group = 'verification'
     testClassesDirs = sourceSets.functionalTest.output.classesDirs
     classpath = sourceSets.functionalTest.runtimeClasspath
-    mustRunAfter test
+    shouldRunAfter test
+    maxParallelForks = 4
 
     reports {
         html.destination = project.file("$html.destination/functional")

--- a/src/functTest/groovy/org/gradle/guides/AbstractFunctionalTest.groovy
+++ b/src/functTest/groovy/org/gradle/guides/AbstractFunctionalTest.groovy
@@ -31,12 +31,7 @@ abstract class AbstractFunctionalTest extends Specification {
     def setup() {
         projectDir = temporaryFolder.root
         buildFile = temporaryFolder.newFile('build.gradle')
-
-        buildFile << """
-            plugins {
-                id 'org.gradle.guides.base'
-            }
-        """
+        new File(projectDir, "gradle.properties").text = "org.gradle.jvmargs=-XX:MaxMetaspaceSize=500m -Xmx500m"
     }
 
     protected BuildResult build(String... arguments) {
@@ -48,7 +43,8 @@ abstract class AbstractFunctionalTest extends Specification {
     }
 
     private GradleRunner createAndConfigureGradleRunner(String... arguments) {
-        GradleRunner.create().withProjectDir(projectDir).withArguments(arguments).withPluginClasspath().forwardOutput()
+        def allArgs = (arguments as List) + ["-S"]
+        GradleRunner.create().withProjectDir(projectDir).withArguments(allArgs).withPluginClasspath().forwardOutput()
     }
 
     static File createDir(File dir, String subDirName) {

--- a/src/functTest/groovy/org/gradle/guides/AbstractGuidesPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/org/gradle/guides/AbstractGuidesPluginFunctionalTest.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.guides
+
+
+import spock.lang.Unroll
+
+abstract class AbstractGuidesPluginFunctionalTest extends AbstractFunctionalTest {
+    abstract String getPluginId()
+
+    def setup() {
+        buildFile << """
+            plugins {
+                id '${pluginId}'
+            }
+        """
+        createContentsDir()
+    }
+
+    @Unroll
+    def "builds the guide using task #task"() {
+        given:
+        asciidocSourceFile << """
+A simple guide
+"""
+        // Should not need to create this
+        temporaryFolder.newFolder("samples")
+
+        when:
+        build(task)
+
+        then:
+        def htmlFile = new File(temporaryFolder.root, 'build/html5/index.html')
+        htmlFile.exists()
+
+        where:
+        task << ["asciidoctor", "assemble"]
+    }
+
+    File getAsciidocSourceFile() {
+        return temporaryFolder.newFile("contents/index.adoc")
+    }
+
+    File createSamplesCodeDir() {
+        temporaryFolder.newFolder('samples', 'code')
+    }
+
+    File createSamplesOutputDir() {
+        temporaryFolder.newFolder('samples', 'output')
+    }
+
+    File createContentsDir() {
+        temporaryFolder.newFolder('contents')
+    }
+}

--- a/src/functTest/groovy/org/gradle/guides/BasePluginFunctionalTest.groovy
+++ b/src/functTest/groovy/org/gradle/guides/BasePluginFunctionalTest.groovy
@@ -17,29 +17,9 @@
 package org.gradle.guides
 
 import org.gradle.testkit.runner.TaskOutcome
-import spock.lang.Unroll
 
-class BasePluginFunctionalTest extends AbstractFunctionalTest {
-    @Unroll
-    def "builds the guide using task #task"() {
-        given:
-        def contentsDir = temporaryFolder.newFolder('contents')
-        new File(contentsDir, 'index.adoc') << """
-A simple guide
-"""
-        // Should not need to create this
-        temporaryFolder.newFolder("samples")
-
-        when:
-        build(task)
-
-        then:
-        def htmlFile = new File(temporaryFolder.root, 'build/html5/index.html')
-        htmlFile.exists()
-
-        where:
-        task << ["asciidoctor", "assemble"]
-    }
+class BasePluginFunctionalTest extends AbstractGuidesPluginFunctionalTest {
+    String pluginId = "org.gradle.guides.base"
 
     def "adds Asciidoctor attributes for samples code and output directory"() {
         given:
@@ -62,8 +42,7 @@ A simple guide
 
     def "can reference attributes for samples directories in Asciidoc generation"() {
         given:
-        def contentsDir = temporaryFolder.newFolder('contents')
-        new File(contentsDir, 'index.adoc') << """
+        asciidocSourceFile << """
 My build file:
 include::{samplescodedir}/helloWorld/build.gradle[]
 Output:
@@ -97,8 +76,7 @@ Hello world!
     def "asciidoctor is out of date if samples change"() {
         given:
         def asciiDoctorTask = ":asciidoctor"
-        def contentsDir = createContentsDir()
-        new File(contentsDir, "index.adoc") << 'This is some sample ascii source'
+        asciidocSourceFile << 'This is some sample ascii source'
         def samplesCodeDir = createSamplesCodeDir()
         def samplesOutputDir = createSamplesOutputDir()
 
@@ -132,9 +110,8 @@ Hello world!
     def "header and footer is injected during asciidoctor postprocessing"() {
         given:
         def asciiDoctorTask = ":asciidoctor"
-        def contentsDir = createContentsDir()
         createSamplesCodeDir()
-        new File(contentsDir, "index.adoc") << 'This is some sample ascii source'
+        asciidocSourceFile << 'This is some sample ascii source'
 
         when:
         build(asciiDoctorTask)
@@ -144,17 +121,5 @@ Hello world!
         htmlFile.contains('<script defer src="https://guides.gradle.org/js/guides')
         htmlFile.contains('<header class="site-layout__header site-header js-site-header" itemscope="itemscope" itemtype="https://schema.org/WPHeader">')
         htmlFile.contains('<footer class="site-layout__footer site-footer" itemscope="itemscope" itemtype="https://schema.org/WPFooter">')
-    }
-
-    private File createSamplesCodeDir() {
-        temporaryFolder.newFolder('samples', 'code')
-    }
-
-    private File createSamplesOutputDir() {
-        temporaryFolder.newFolder('samples', 'output')
-    }
-
-    private File createContentsDir() {
-        temporaryFolder.newFolder('contents')
     }
 }

--- a/src/functTest/groovy/org/gradle/guides/BasePluginFunctionalTest.groovy
+++ b/src/functTest/groovy/org/gradle/guides/BasePluginFunctionalTest.groovy
@@ -17,8 +17,29 @@
 package org.gradle.guides
 
 import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Unroll
 
 class BasePluginFunctionalTest extends AbstractFunctionalTest {
+    @Unroll
+    def "builds the guide using task #task"() {
+        given:
+        def contentsDir = temporaryFolder.newFolder('contents')
+        new File(contentsDir, 'index.adoc') << """
+A simple guide
+"""
+        // Should not need to create this
+        temporaryFolder.newFolder("samples")
+
+        when:
+        build(task)
+
+        then:
+        def htmlFile = new File(temporaryFolder.root, 'build/html5/index.html')
+        htmlFile.exists()
+
+        where:
+        task << ["asciidoctor", "assemble"]
+    }
 
     def "adds Asciidoctor attributes for samples code and output directory"() {
         given:

--- a/src/functTest/groovy/org/gradle/guides/GettingStartedPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/org/gradle/guides/GettingStartedPluginFunctionalTest.groovy
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.guides
+
+class GettingStartedPluginFunctionalTest extends AbstractGuidesPluginFunctionalTest {
+    String pluginId = "org.gradle.guides.getting-started"
+}

--- a/src/functTest/groovy/org/gradle/guides/TopicalPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/org/gradle/guides/TopicalPluginFunctionalTest.groovy
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.guides
+
+class TopicalPluginFunctionalTest extends AbstractGuidesPluginFunctionalTest {
+    String pluginId = "org.gradle.guides.topical"
+}

--- a/src/functTest/groovy/org/gradle/guides/TutorialPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/org/gradle/guides/TutorialPluginFunctionalTest.groovy
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.guides
+
+class TutorialPluginFunctionalTest extends AbstractGuidesPluginFunctionalTest {
+    String pluginId = "org.gradle.guides.tutorial"
+}

--- a/src/main/groovy/org/gradle/guides/BasePlugin.groovy
+++ b/src/main/groovy/org/gradle/guides/BasePlugin.groovy
@@ -42,7 +42,7 @@ class BasePlugin implements Plugin<Project> {
     static final String CHECK_LINKS_TASK = 'checkLinks'
 
     void apply(Project project) {
-        project.apply plugin : org.gradle.api.plugins.BasePlugin
+        project.apply plugin : 'lifecycle-base'
 
         addGuidesExtension(project)
         addGradleRunnerSteps(project)
@@ -131,6 +131,8 @@ class BasePlugin implements Plugin<Project> {
         }
 
         lazyConfigureMoreAsciidoc(asciidoc)
+
+        project.tasks.getByName("assemble").dependsOn asciidoc
 
         // TODO - rework the above to use lazy configuration
 

--- a/src/main/groovy/org/gradle/guides/BasePlugin.groovy
+++ b/src/main/groovy/org/gradle/guides/BasePlugin.groovy
@@ -24,7 +24,6 @@ import org.asciidoctor.gradle.AsciidoctorTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.internal.IConventionAware
 import org.gradle.api.tasks.PathSensitivity
 
 /**
@@ -133,15 +132,14 @@ class BasePlugin implements Plugin<Project> {
 
         lazyConfigureMoreAsciidoc(asciidoc)
 
-        def viewTask = project.tasks.create("viewGuide", ViewGuide).with {
-            (it as IConventionAware).conventionMapping.map("outputDir") {
-                asciidoc.outputDir
-            }
-            dependsOn asciidoc
-        }
+        // TODO - rework the above to use lazy configuration
 
-        if (project.gradle.startParameter.continuous) {
-            asciidoc.finalizedBy viewTask
+        def asciidocIndexFile = project.layout.file(project.tasks.named("asciidoctor").map { new File(it.outputDir, "html5/index.html") })
+
+        project.tasks.register("viewGuide", ViewGuide) {
+            group = "Documentation"
+            description = "Generates the guide and open in the browser"
+            indexFile = asciidocIndexFile
         }
     }
 

--- a/src/main/groovy/org/gradle/guides/ViewGuide.groovy
+++ b/src/main/groovy/org/gradle/guides/ViewGuide.groovy
@@ -1,14 +1,17 @@
 package org.gradle.guides
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.specs.Specs
-import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.TaskAction
 
-class ViewGuide extends DefaultTask {
+import java.awt.*
 
-    @Internal
-    File outputDir
+abstract class ViewGuide extends DefaultTask {
+
+    @InputFile
+    abstract RegularFileProperty getIndexFile()
 
     ViewGuide() {
         outputs.upToDateWhen(Specs.satisfyNone())
@@ -16,47 +19,6 @@ class ViewGuide extends DefaultTask {
 
     @TaskAction
     void action() {
-        if (isMacOs()) {
-            def url = getOutputDir().absoluteFile.toURI().toASCIIString()
-                    .replaceFirst("^file:/(?!=/)", "file:///")
-
-            project.exec {
-                it.commandLine "osascript", "-e", """
-                    try
-                        tell application "Finder" to get application file id "com.google.Chrome"
-                        set appExists to true
-                    on error
-                        set appExists to false
-                    end try
-                    if appExists then
-                        tell application "Google Chrome"
-                            set theUrl to "$url"
-                            set found to false
-                            set theWindowIndex to 0
-                            repeat with theWindow in every window
-                                set theTabIndex to 0
-                                repeat with theTab in every tab of theWindow
-                                    set theTabIndex to theTabIndex + 1
-                                    if theTab's URL starts with theUrl then
-                                        set found to true
-                                        tell application "Google Chrome" to set active tab index of theWindow to theTabIndex
-                                        tell theTab to reload
-                                    end if
-                                end repeat
-                            end repeat
-                            if not found then
-                                set URL of (active tab of (make new window)) to theUrl & "/html5/index.html"
-                            end if
-                        end tell
-                    end if
-                """
-            }
-        } else {
-            didWork = false
-        }
-    }
-
-    private static boolean isMacOs() {
-        System.getProperty("os.name").toLowerCase().contains("mac")
+        Desktop.desktop.open(getIndexFile().get().asFile)
     }
 }


### PR DESCRIPTION
The PR:

- fixes `viewGuide` so that it works in more places and takes the user's preferences into account.
- adds the `asciidoctor` task as a dependency of the `assemble` task, so that the output of the project (i.e. the guide) is built when a user or tooling uses the standard lifecycle tasks.
- adds some test coverage for the guides plugins.