### PR TITLE
Model minimum Gradle version for the guide

### DIFF
--- a/src/functTest/groovy/org/gradle/guides/BasePluginFunctionalTest.groovy
+++ b/src/functTest/groovy/org/gradle/guides/BasePluginFunctionalTest.groovy
@@ -122,4 +122,48 @@ Hello world!
         htmlFile.contains('<header class="site-layout__header site-header js-site-header" itemscope="itemscope" itemtype="https://schema.org/WPHeader">')
         htmlFile.contains('<footer class="site-layout__footer site-footer" itemscope="itemscope" itemtype="https://schema.org/WPFooter">')
     }
+
+    def "defaults to current Gradle version for minimum Gradle version of the guide"() {
+        given:
+        buildFile << """
+            task verifyAsciidoctorAttributes {
+                doLast {
+                    assert asciidoctor.attributes['gradle-version'] == gradle.gradleVersion
+                    assert asciidoctor.attributes['user-manual'] == "https://docs.gradle.org/\${gradle.gradleVersion}/userguide/".toString()
+                    assert asciidoctor.attributes['language-reference'] == "https://docs.gradle.org/\${gradle.gradleVersion}/dsl/".toString()
+                    assert asciidoctor.attributes['api-reference'] == "https://docs.gradle.org/\${gradle.gradleVersion}/javadoc/".toString()
+                }
+            }
+        """
+
+        when:
+        build('verifyAsciidoctorAttributes')
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "can configure the minimum Gradle version of the guide"() {
+        given:
+        buildFile << """
+            guide {
+                minimumGradleVersion = "5.2"
+            }
+
+            task verifyAsciidoctorAttributes {
+                doLast {
+                    assert asciidoctor.attributes['gradle-version'] == '5.2'
+                    assert asciidoctor.attributes['user-manual'] == 'https://docs.gradle.org/5.2/userguide/'
+                    assert asciidoctor.attributes['language-reference'] == 'https://docs.gradle.org/5.2/dsl/'
+                    assert asciidoctor.attributes['api-reference'] == 'https://docs.gradle.org/5.2/javadoc/'
+                }
+            }
+        """
+
+        when:
+        build('verifyAsciidoctorAttributes')
+
+        then:
+        noExceptionThrown()
+    }
 }

--- a/src/main/groovy/org/gradle/guides/GuidesExtension.groovy
+++ b/src/main/groovy/org/gradle/guides/GuidesExtension.groovy
@@ -17,20 +17,16 @@
 package org.gradle.guides
 
 import groovy.transform.CompileStatic
-import org.gradle.api.Project
+import org.gradle.api.provider.Property
 
 /**
  *
  * @since 0.1
  */
 @CompileStatic
-class GuidesExtension {
-
-    GuidesExtension(Project project) {
-    }
-
-    /** Path of repository relative to {@code https://github.com}.
-     *
+abstract class GuidesExtension {
+    /**
+     * Path of repository relative to {@code https://github.com}.
      */
     String repoPath
 
@@ -40,4 +36,10 @@ class GuidesExtension {
      * @since 0.5
      */
     String mainAuthor
+
+    /**
+     * Minimum Gradle version this guide works on.
+     * @since 0.15.7
+     */
+    abstract Property<String> getMinimumGradleVersion()
 }


### PR DESCRIPTION
Fixes https://github.com/gradle/guides-private/issues/57

Add models for minimum Gradle version for the guide.