### PR TITLE
 Attach GitHub repository configuration to `setupGuide` task

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -108,6 +108,10 @@ This should be applied in the authoring of all new Topical guides
 
 == Changelog
 
+=== 0.15.11
+
+- Add GitHub repository configuration task to `setupGuide`.
+
 === 0.15.10
 
 - Add conventions for the `guide` DSL:

--- a/src/main/groovy/org/gradle/guides/BasePlugin.groovy
+++ b/src/main/groovy/org/gradle/guides/BasePlugin.groovy
@@ -65,10 +65,14 @@ class BasePlugin implements Plugin<Project> {
             it.title.set(guide.title)
         }
 
-        project.tasks.withType(ConfigureGitHubRepository).configureEach {
+        def configureGitHubRepositoryTask = project.tasks.register("configureGitHubRepository", ConfigureGitHubRepository) {
             it.repositorySlug.set(guide.repositoryPath)
             it.repositoryHomepage.set(guide.repositoryPath.map { new URL("https://guides.gradle.org/${it.split('/')[1]}") })
             it.repositoryDescription.set(guide.description)
+        }
+
+        project.tasks.named(SetupPlugin.SETUP_GUIDE_TASK_NAME) { Task it ->
+            it.dependsOn(configureGitHubRepositoryTask)
         }
     }
 


### PR DESCRIPTION
This change was forgotten when first introducing the `setupGuide` task.