### PR TITLE
Fix lambdas (and upgrade to Gradle 6.0.1)

### DIFF
--- a/src/functTest/groovy/org/gradle/samples/IncrementalSamplesFunctionalTest.groovy
+++ b/src/functTest/groovy/org/gradle/samples/IncrementalSamplesFunctionalTest.groovy
@@ -128,18 +128,34 @@ endif::[]
 
         then:
         assertSampleTasksExecutedAndNotSkipped(result1)
-        result1.task(':assemble').outcome == SUCCESS
         result1.task(':generateSampleIndex').outcome == SUCCESS
         result1.task(':asciidocSampleIndex').outcome == SUCCESS
+        result1.task(':asciidoctorDemoSample').outcome == SUCCESS
+        result1.task(':generateWrapperForDemoSample').outcome == SUCCESS
+        result1.task(':installDemoGroovyDslSample').outcome == SUCCESS
+        result1.task(':compressDemoGroovyDslSample').outcome == SUCCESS
+        result1.task(':installDemoKotlinDslSample').outcome == SUCCESS
+        result1.task(':compressDemoKotlinDslSample').outcome == SUCCESS
+        result1.task(':installDemoSample').outcome == SUCCESS
+        result1.task(':assembleDemoSample').outcome == SUCCESS
+        result1.task(':assemble').outcome == SUCCESS
 
         when:
         def result2 = build("assemble")
 
         then:
         assertSampleTasksSkipped(result2)
-        result2.task(':assemble').outcome in SKIPPED_TASK_OUTCOMES
         result2.task(':generateSampleIndex').outcome in SKIPPED_TASK_OUTCOMES
         result2.task(':asciidocSampleIndex').outcome in SKIPPED_TASK_OUTCOMES
+        result2.task(':asciidoctorDemoSample').outcome in SKIPPED_TASK_OUTCOMES
+        result2.task(':generateWrapperForDemoSample').outcome in SKIPPED_TASK_OUTCOMES
+        result2.task(':installDemoGroovyDslSample').outcome in SKIPPED_TASK_OUTCOMES
+        result2.task(':compressDemoGroovyDslSample').outcome in SKIPPED_TASK_OUTCOMES
+        result2.task(':installDemoKotlinDslSample').outcome in SKIPPED_TASK_OUTCOMES
+        result2.task(':compressDemoKotlinDslSample').outcome in SKIPPED_TASK_OUTCOMES
+        result2.task(':installDemoSample').outcome in SKIPPED_TASK_OUTCOMES
+        result2.task(':assembleDemoSample').outcome in SKIPPED_TASK_OUTCOMES
+        result2.task(':assemble').outcome in SKIPPED_TASK_OUTCOMES
     }
 
     def "executes Asciidoctor and Zip tasks when README content change"() {


### PR DESCRIPTION
This fixes the following problem in the `gradle/gradle` build:

```text
Path	:docs:asciidoctorAndroidApplicationSample	
Type	org.asciidoctor.gradle.AsciidoctorTask	
The task was not up-to-date because of the following reasons:	
Additional action for task ':docs:asciidoctorAndroidApplicationSample': was implemented by the Java lambda 'org.gradle.samples.internal.SamplesPlugin$$Lambda$730/0x0000000840f18040'. Using Java lambdas is not supported, use an (anonymous) inner class instead.	
```