### PR TITLE
Keep execution flag wrapper script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 
     compile 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.9.2'
     compile 'org.ajoberstar:gradle-git-publish:2.0.0-rc.2'
+    compile 'org.apache.ant:ant:1.9.13'
 
     runtime 'gradle.plugin.org.ysb33r.gradle:gradle-cloudci-plugin:2.3'
     runtime 'gradle.plugin.org.ysb33r.gradle:gradle-runner:1.1'

--- a/src/functTest/groovy/org/gradle/samples/SamplesPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/org/gradle/samples/SamplesPluginFunctionalTest.groovy
@@ -595,10 +595,9 @@ endif::[]
 
     private void assertCanRunHelpTask(File zipFile) {
         def workingDirectory = new File(temporaryFolder.root, zipFile.name)
-        def ant = new AntBuilder()
-        ant.unzip(src: zipFile, dest: workingDirectory)
+        "unzip ${zipFile.getCanonicalPath()} -d ${workingDirectory.getCanonicalPath()}".execute().waitFor()
 
-        new File(workingDirectory, 'gradlew').executable = true
+        assert new File(workingDirectory, 'gradlew').canExecute()
         def process = "${workingDirectory}/gradlew help".execute(null, workingDirectory)
         def stdoutThread = Thread.start { process.in.eachLine { println(it) } }
         def stderrThread = Thread.start { process.err.eachLine { println(it) } }


### PR DESCRIPTION
This is quite the annoying thing as it's near impossible to implement
quickly with vanilla JDK and most implementation are either ignoring
during archiving or during unarchiving.